### PR TITLE
Feat/edit endpoints

### DIFF
--- a/src/pages/api/submissions/add.ts
+++ b/src/pages/api/submissions/add.ts
@@ -27,7 +27,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         const collection = await db
             .collection("Submissions")
             .find({})
-            // .limit(30)
             .toArray();
 
         res.status(201).json({ success: true, data: collection });

--- a/src/pages/api/submissions/edit.ts
+++ b/src/pages/api/submissions/edit.ts
@@ -32,7 +32,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         const collection = await db
             .collection("Submissions")
             .find({})
-            // .limit(30)
             .toArray();
 
         res.status(201).json({ success: true, data: collection });

--- a/src/pages/api/users/edit.ts
+++ b/src/pages/api/users/edit.ts
@@ -36,7 +36,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         const collection = await db
             .collection("Users")
             .find({})
-            // .limit(30)
             .toArray();
 
         res.status(201).json({ success: true, data: collection });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,72 +1,7 @@
-// default "nothing" home page
-// export default function Home() {
-//     return (
-//         <div>
-//             Hello
-//         </div>
-//     )
-// }
-
-// submission edit testing
-import Submission from "@/types/Submission";
-
 export default function Home() {
-    const test = async () => {
-        const randomNumber = Math.random();
-
-        // Create an initial document to add
-        const original: Submission = {
-            id: "fooAuthor|barTitle|" + randomNumber,
-            author: "fooAuthor",
-            title: "barTitle",
-            issue: "quxIssue",
-            date: "bazDate",
-            image: "corgeImage",
-            wordDoc: "graultDoc",
-        }
-
-        // Add it
-        await fetch("http://localhost:3000/api/submissions/add", {
-            method: "POST",
-            body: JSON.stringify(original),
-        })
-            .then(res => res.json())
-            .then(res => {
-                if (res.success) {
-                    console.log("Successfully added submission.");
-                    console.log(res.data);
-                } else {
-                    console.log("Add failed.")
-                }
-            });
-
-        // Create an edited version
-        const edit: Submission = {
-            id: "fooAuthor|barTitle|" + randomNumber,
-            author: "EDITED!",
-            title: "barTitle",
-            issue: "quxIssue",
-            date: "bazDate",
-            image: "corgeImage",
-            wordDoc: "graultDoc",
-        }
-
-        await fetch('http://localhost:3000/api/submissions/edit', {
-            method: 'PATCH',
-            body: JSON.stringify(edit),
-        })
-            // convert promise to JSON
-            .then(res => res.json())
-            // print out results
-            .then(res => {
-                if (res.success) {
-                    console.log("Successfully edited submission.");
-                    console.log(res.data);
-                } else {
-                    console.log("Edit failed");
-                }
-            });
-    };
-
-    test();
+    return (
+        <div>
+            Hello
+        </div>
+    )
 }


### PR DESCRIPTION
# Trello card link

[https://trello.com/c/P0zsHsFv](https://trello.com/c/P0zsHsFv)

# Pull request/feature description

* added `submissions/edit` endpoint
* added `users/edit` endpoint

Note: `users/edit` endpoint is speculative for now since we don't have a `users/add` endpoint to go off of, so it's just the `submissions/edit` endpoint with a few changes.

The home page (`index.tsx`) is just a test of the addition and edition of submissions.

Note: I've changed the debug data returned by `submissions/add` and `submissions/edit` to *not* limit to 30 entries, so as not to be limited to the first 30. We're at around 120 by now.